### PR TITLE
add a Dockerfile for use with binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM sagemath/sagemath:8.3
+COPY --chown=sage:sage . ${HOME}/sage-combinat-widgets
+WORKDIR ${HOME}/sage-combinat-widgets
+RUN sage -pip install .


### PR DESCRIPTION
it copies the sage-combinat-widgets into the HOME directory, the pip-installs it into
the Sage prefix

CC @zerline 