### PR TITLE
Add 'import os' to run_tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ def readfile(filename):
 # For the tests
 class SageTest(TestCommand):
     def run_tests(self):
+        import os
         errno = os.system("sage -t --force-lib sage_widget_adapters")
         if errno != 0:
             sys.exit(1)


### PR DESCRIPTION
Without it, `sage setup.py test` does not work. 